### PR TITLE
fix error when handling the extended ASCII codes in response output

### DIFF
--- a/pycorenlp/corenlp.py
+++ b/pycorenlp/corenlp.py
@@ -27,6 +27,7 @@ class StanfordCoreNLP:
             self.server_url, params={
                 'properties': str(properties)
             }, data=data, headers={'Connection': 'close'})
+        r.encoding = 'utf-8'
         output = r.text
         if ('outputFormat' in properties
              and properties['outputFormat'] == 'json'):


### PR DESCRIPTION
I find out that when supplying a short name text with extended ASCII code (e.g., "Arès Méroueh") will generate an error in the results's 'originalText' tag. The reason is that requests lib will guess the response's encoding. In the case of "Arès Méroueh", it will give result like ISO8859-1, which is not true. According to the standford coreNLP. The default response encoding is utf-8. Adding this line( r.encoding = 'utf-8') will eliminate error like this. 

In order to make the code more robust, one may change the interface and allow user to specify response encoding. 