### PR TITLE
Try Except around encode call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## My Contribution in this Fork
+I removed a call to encode inside the annotate function so that text that is already encoded before being passed into the function will not crash it.
+
 # py-corenlp
 Python wrapper for Stanford CoreNLP.  This simply wraps the API from the server included with CoreNLP 3.6.0.  See the CoreNLP server [API documentation](http://stanfordnlp.github.io/CoreNLP/corenlp-server.html#api-documentation) for details.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-## My Contribution in this Fork
-I removed a call to encode inside the annotate function so that text that is already encoded before being passed into the function will not crash it.
-
 # py-corenlp
 Python wrapper for Stanford CoreNLP.  This simply wraps the API from the server included with CoreNLP 3.6.0.  See the CoreNLP server [API documentation](http://stanfordnlp.github.io/CoreNLP/corenlp-server.html#api-documentation) for details.
 

--- a/pycorenlp/corenlp.py
+++ b/pycorenlp/corenlp.py
@@ -22,7 +22,7 @@ class StanfordCoreNLP:
             '$ cd stanford-corenlp-full-2015-12-09/ \n'
             '$ java -mx4g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer')
 
-        data = text.encode()
+        data = text #.encode()
         r = requests.post(
             self.server_url, params={
                 'properties': str(properties)

--- a/pycorenlp/corenlp.py
+++ b/pycorenlp/corenlp.py
@@ -21,8 +21,13 @@ class StanfordCoreNLP:
             raise Exception('Check whether you have started the CoreNLP server e.g.\n'
             '$ cd stanford-corenlp-full-2015-12-09/ \n'
             '$ java -mx4g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer')
+        
+        # only encode if needed
+        try:
+            data = text.encode()
+        except:
+            data = text
 
-        data = text #.encode()
         r = requests.post(
             self.server_url, params={
                 'properties': str(properties)


### PR DESCRIPTION
In a project that I was using this code for, I had to pass already encoded text into the annotate function, and the encode call in the annotate function caused an exception. So I simply added a try except around the call to allow a wider range of inputs and to get it to work with my project.

Also, don't worry about the commit 'update readme', the readme was put back into original form by the last commit.