### PR TITLE
Adding properties param for tokensregex, semgrex and regex methods

### DIFF
--- a/example.py
+++ b/example.py
@@ -14,3 +14,8 @@ if __name__ == '__main__':
     print(output)
     output = nlp.semgrex(text, pattern='{tag: VBD}', filter=False)
     print(output)
+    output = nlp.semgrex(text, pattern='{ner: PERS}', filter=False, properties={
+        'annotators': 'tokenize,ssplit,ner,depparse',
+        'pipelineLanguage': 'en',
+    })
+    print(output)

--- a/pycorenlp/corenlp.py
+++ b/pycorenlp/corenlp.py
@@ -36,21 +36,25 @@ class StanfordCoreNLP:
                 pass
         return output
 
-    def tokensregex(self, text, pattern, filter):
-        return self.regex('/tokensregex', text, pattern, filter)
+    def tokensregex(self, text, pattern, filter, properties = None):
+        return self.regex('/tokensregex', text, pattern, filter, properties)
 
-    def semgrex(self, text, pattern, filter):
-        return self.regex('/semgrex', text, pattern, filter)
+    def semgrex(self, text, pattern, filter, properties = None):
+        return self.regex('/semgrex', text, pattern, filter, properties)
 
-    def regex(self, endpoint, text, pattern, filter):
+    def regex(self, endpoint, text, pattern, filter, properties = None):
+        assert isinstance(text, str)
+        data = text.encode()
         r = requests.get(
             self.server_url + endpoint, params={
-                'pattern':  pattern,
+                'pattern': pattern,
+                'properties': str(properties or {}),
                 'filter': filter
-            }, data=text)
+            }, data=data)
+        r.encoding = 'utf-8'
         output = r.text
         try:
-            output = json.loads(r.text)
+            output = json.loads(r.text, encoding='utf-8', strict=True)
         except:
             pass
         return output


### PR DESCRIPTION
As of released in CoreNLP v3.9.0, `StanfordCoreNLPServer` class now accepts the `properties` param for `tokensregex` and `semgrex` as well as for `tregex` endpoint.

This para works similarly as as the "annotate" endpoint does, allowing for language selection and custom annotators such as `NER`.  It is not possible to use them without this.

Reference:
https://github.com/stanfordnlp/CoreNLP/commit/8a2f5fbca514c5b1f01cdb7cc0ca96ed64973b82
https://github.com/stanfordnlp/CoreNLP/commit/76f2bcdcde0d2266e7ab50ebb95a629c407f5922